### PR TITLE
[MM-36445] Adding elasticsearch 7.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.14.0
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.0.0
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu


### PR DESCRIPTION
#### Summary
We want to remove support for elasticsearch 5 & 6 but first we need to add an image for elasticsearch 7. Our pipelines all use es 6.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36445

#### Related PRs
https://github.com/mattermost/enterprise/pull/1020

